### PR TITLE
Remove dead code

### DIFF
--- a/pysoot/errors.py
+++ b/pysoot/errors.py
@@ -6,14 +6,6 @@ class ParameterError(PySootError):
     pass
 
 
-class JythonClientException(PySootError):
-    pass
-
-
-class RecvException(PySootError):
-    pass
-
-
 class JavaNotFoundError(PySootError):
     pass
 

--- a/pysoot/lifter.py
+++ b/pysoot/lifter.py
@@ -8,7 +8,6 @@ from .errors import JavaNotFoundError, MissingJavaRuntimeJarsError, ParameterErr
 
 
 log = logging.getLogger("pysoot.lifter")
-self_dir = os.path.dirname(os.path.realpath(__file__))
 
 
 class Lifter:
@@ -20,11 +19,8 @@ class Lifter:
         additional_jars=None,
         additional_jar_roots=None,
         android_sdk=None,
-        save_to_file=None,
     ):
-
         self.input_file = os.path.realpath(input_file)
-        self.save_to_file = save_to_file
         allowed_irs = ["shimple", "jimple"]
         if ir_format not in allowed_irs:
             raise ParameterError("ir_format needs to be in " + repr(allowed_irs))
@@ -85,7 +81,6 @@ class Lifter:
             "ir_format",
             "android_sdk",
             "soot_classpath",
-            "main_class",
         ]
         for s in settings:
             config[s] = str(getattr(self, s, None))
@@ -97,15 +92,7 @@ class Lifter:
 
         log.info("Running Soot with the following config: " + repr(config))
         self.soot_wrapper.init(**config)
-        if self.save_to_file is None:
-            self.classes = self.soot_wrapper.get_classes()
-        else:
-            ipc_options = {
-                "return_result": False,
-                "return_pickle": False,
-                "save_pickle": self.save_to_file,
-            }
-            self.classes = self.soot_wrapper.get_classes(_ipc_options=ipc_options)
+        self.classes = self.soot_wrapper.get_classes()
 
 
 def _get_java_home() -> str:

--- a/pysoot/soot_manager.py
+++ b/pysoot/soot_manager.py
@@ -23,7 +23,6 @@ class SootManager:
 
     def init(
         self,
-        main_class,
         input_file,
         input_format: str,
         android_sdk: str | None,

--- a/pysoot/sootir/__init__.py
+++ b/pysoot/sootir/__init__.py
@@ -30,7 +30,6 @@ attribute_conversion_dict = {
     0x10000: "CONSTRUCTOR",
     0x20000: "DECLARED_SYNCHRONIZED",
 }
-attribute_conversion_dict_inv = {v: k for k, v in attribute_conversion_dict.items()}
 
 
 def convert_soot_attributes(attributes):

--- a/pysoot/sootir/soot_expr.py
+++ b/pysoot/sootir/soot_expr.py
@@ -186,7 +186,7 @@ class SootInvokeExpr(SootExpr):
 
     @staticmethod
     def list_to_arg_str(args):
-        return ", ".join([str(arg) for arg in args])
+        return ", ".join(str(arg) for arg in args)
 
 
 @dataclass(slots=True, unsafe_hash=True)
@@ -201,9 +201,9 @@ class SootVirtualInvokeExpr(SootInvokeExpr):
 
     @staticmethod
     def from_ir(type_, expr_name, ir_expr):
-        args = tuple([SootValue.from_ir(arg) for arg in ir_expr.getArgs()])
+        args = tuple(SootValue.from_ir(arg) for arg in ir_expr.getArgs())
         called_method = ir_expr.getMethod()
-        params = tuple([str(param) for param in called_method.getParameterTypes()])
+        params = tuple(str(param) for param in called_method.getParameterTypes())
 
         return SootVirtualInvokeExpr(
             type=type_,
@@ -227,8 +227,8 @@ class SootDynamicInvokeExpr(SootInvokeExpr):
         #        for arg in ir_expr.getBootstrapArgs()])
         bootstrap_args = None
         method = ir_expr.getMethod()
-        method_params = tuple([str(param) for param in method.getParameterTypes()])
-        args = tuple([SootValue.from_ir(arg) for arg in ir_expr.getArgs()])
+        method_params = tuple(str(param) for param in method.getParameterTypes())
+        args = tuple(SootValue.from_ir(arg) for arg in ir_expr.getArgs())
 
         class_name = str(method.getDeclaringClass().getName())
         method_name = str(method.getName())
@@ -256,7 +256,7 @@ class SootInterfaceInvokeExpr(SootInvokeExpr):
 
     @staticmethod
     def from_ir(type_, expr_name, ir_expr):
-        args = tuple([SootValue.from_ir(arg) for arg in ir_expr.getArgs()])
+        args = tuple(SootValue.from_ir(arg) for arg in ir_expr.getArgs())
         called_method = ir_expr.getMethod()
         params = tuple(str(param) for param in called_method.getParameterTypes())
 

--- a/pysoot/sootir/soot_statement.py
+++ b/pysoot/sootir/soot_statement.py
@@ -43,9 +43,6 @@ class DefinitionStmt(SootStmt):
 
 @dataclass(slots=True, unsafe_hash=True)
 class AssignStmt(DefinitionStmt):
-    def __str__(self):
-        return f"{str(self.left_op)} = {str(self.right_op)}"
-
     @staticmethod
     def from_ir(label, offset, ir_stmt, stmt_map=None):
         return AssignStmt(
@@ -184,9 +181,7 @@ class LookupSwitchStmt(SootStmt):
     def from_ir(label, offset, ir_stmt, stmt_map=None):
         lookup_values = [int(str(v)) for v in ir_stmt.getLookupValues()]
         targets = [stmt_map[t] for t in ir_stmt.getTargets()]
-        lookup_values_and_targets = frozendict(
-            {k: v for k, v in zip(lookup_values, targets)}
-        )
+        lookup_values_and_targets = frozendict(zip(lookup_values, targets))
 
         return LookupSwitchStmt(
             label=label,
@@ -217,7 +212,7 @@ class TableSwitchStmt(SootStmt):
         dict_iter = zip(
             range(ir_stmt.getLowIndex(), ir_stmt.getHighIndex() + 1), targets
         )
-        lookup_values_and_targets = {k: v for k, v in dict_iter}
+        lookup_values_and_targets = dict(dict_iter)
 
         return TableSwitchStmt(
             label=label,


### PR DESCRIPTION
- Remove unused JythonClientException and RecvException from errors.py
- Remove unused self_dir module variable from lifter.py
- Remove dead save_to_file/_ipc_options code path from lifter.py
- Remove unused main_class parameter from lifter.py and soot_manager.py
- Remove unused attribute_conversion_dict_inv from sootir/__init__.py
- Remove duplicate AssignStmt.__str__ (identical to parent DefinitionStmt)
- Simplify tuple([list comp]) to tuple(gen expr) in soot_expr.py
- Simplify redundant dict comprehensions in soot_statement.py