### PR TITLE
Fix IR field types: statement labels/targets are ints, not statements

### DIFF
--- a/pysoot/sootir/soot_block.py
+++ b/pysoot/sootir/soot_block.py
@@ -7,7 +7,7 @@ from .soot_statement import SootStmt
 
 @dataclass(slots=True, unsafe_hash=True)
 class SootBlock:
-    label: str
+    label: int
     statements: tuple[SootStmt, ...]
     idx: int | None
 

--- a/pysoot/sootir/soot_statement.py
+++ b/pysoot/sootir/soot_statement.py
@@ -104,7 +104,7 @@ class ExitMonitorStmt(SootStmt):
 
 @dataclass(slots=True, unsafe_hash=True)
 class GotoStmt(SootStmt):
-    target: SootStmt
+    target: int
 
     def __str__(self):
         return f"goto {self.target}"
@@ -117,7 +117,7 @@ class GotoStmt(SootStmt):
 @dataclass(slots=True, unsafe_hash=True)
 class IfStmt(SootStmt):
     condition: SootValue
-    target: SootStmt
+    target: int
 
     def __str__(self):
         return f"if({str(self.condition)}) goto {str(self.target)}"
@@ -169,8 +169,8 @@ class ReturnVoidStmt(SootStmt):
 @dataclass(slots=True, unsafe_hash=True)
 class LookupSwitchStmt(SootStmt):
     key: SootValue
-    lookup_values_and_targets: frozendict[int, SootStmt]
-    default_target: SootStmt
+    lookup_values_and_targets: frozendict[int, int]
+    default_target: int
 
     def __str__(self):
         targets = repr(self.lookup_values_and_targets)
@@ -197,9 +197,9 @@ class TableSwitchStmt(SootStmt):
     key: SootValue
     low_index: int
     high_index: int
-    targets: tuple[SootStmt, ...]
-    lookup_values_and_targets: frozendict[int, SootStmt]
-    default_target: SootStmt
+    targets: tuple[int, ...]
+    lookup_values_and_targets: frozendict[int, int]
+    default_target: int
 
     def __str__(self):
         targets = repr(self.lookup_values_and_targets)


### PR DESCRIPTION
## Summary

Several IR fields in `sootir/` are annotated as `SootStmt` or `str` but actually hold `int` values (sequential statement indices used as labels). This PR fixes the annotations to match reality.

| File | Field | Was | Now |
|---|---|---|---|
| `soot_block.py` | `SootBlock.label` | `str` | `int` |
| `soot_statement.py` | `GotoStmt.target` | `SootStmt` | `int` |
| `soot_statement.py` | `IfStmt.target` | `SootStmt` | `int` |
| `soot_statement.py` | `LookupSwitchStmt.lookup_values_and_targets` | `frozendict[int, SootStmt]` | `frozendict[int, int]` |
| `soot_statement.py` | `LookupSwitchStmt.default_target` | `SootStmt` | `int` |
| `soot_statement.py` | `TableSwitchStmt.targets` | `tuple[SootStmt, ...]` | `tuple[int, ...]` |
| `soot_statement.py` | `TableSwitchStmt.lookup_values_and_targets` | `frozendict[int, SootStmt]` | `frozendict[int, int]` |
| `soot_statement.py` | `TableSwitchStmt.default_target` | `SootStmt` | `int` |

## Why

The `from_ir` factory methods construct these fields from `stmt_map[ir_unit]`, where `stmt_map` is `{u: i for i, u in enumerate(units)}` — i.e. ints. Type checkers in strict mode flag the mismatch.

angr's usage confirms ints are the intended semantics:
- `angr/analyses/cfg/cfg_fast_soot.py`: `block.label + len(block.statements)` (arithmetic)
- `angr/engines/soot/statements/base.py`: `current_method.block_by_label[instr]` (dict lookup keyed by `block.label`)
- `angr/engines/soot/statements/switch.py`: targets passed to `_get_bb_addr_from_instr`

## Test plan
- [ ] No runtime behavior change — only annotations are touched
- [ ] Ruff passes
- [ ] Existing test suite (`pytest tests/`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)